### PR TITLE
Chart of different Windows builds

### DIFF
--- a/windows-cu-chart
+++ b/windows-cu-chart
@@ -1,0 +1,8 @@
+// Shows the pie chart of Windows cumulative update versions
+OperatingSystem 
+| project Device, BuildNumber
+| join (Registry('HKLM:\\Software\\Microsoft\\Windows NT\\CurrentVersion')
+| where Property =='UBR' | project Device, CU=Value)
+| project Device, FullBuild=strcat(BuildNumber,'.',tostring(CU))
+| summarize count() by FullBuild
+| render piechart with(title='Windows CUs')


### PR DESCRIPTION
This pie chart shows how many devices have different Windows cumulative update levels. With the information, you can easily identify how many devices don't have the latest cumulative update installed.